### PR TITLE
iter22

### DIFF
--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -1,26 +1,114 @@
 package main
 
 import (
+	"embed"
+	"encoding/json"
 	"flag"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/caarlos0/env/v10"
 	"github.com/dlomanov/mon/internal/apps/agent"
 	"github.com/dlomanov/mon/internal/apps/agent/collector"
 	"github.com/dlomanov/mon/internal/apps/agent/reporter"
+	"gopkg.in/yaml.v2"
 )
 
 type rawConfig struct {
-	Addr           string `env:"ADDRESS"`
-	PollInterval   uint64 `env:"POLL_INTERVAL"`
-	ReportInterval uint64 `env:"REPORT_INTERVAL"`
-	Key            string `env:"KEY"`
-	RateLimit      uint64 `env:"RATE_LIMIT"`
-	LogLevel       string `env:"LOG_LEVEL"`
-	PublicKeyPath  string `env:"CRYPTO_KEY"`
+	Addr           string `json:"addr" env:"ADDRESS"`
+	PollInterval   uint64 `json:"poll_interval" env:"POLL_INTERVAL"`
+	ReportInterval uint64 `json:"report_interval" env:"REPORT_INTERVAL"`
+	Key            string `json:"key" env:"KEY"`
+	RateLimit      uint64 `json:"rate_limit" env:"RATE_LIMIT"`
+	LogLevel       string `json:"log_level" env:"LOG_LEVEL"`
+	PublicKeyPath  string `json:"crypto_key" env:"CRYPTO_KEY"`
+	ConfigPath     string `json:"config" env:"CONFIG"`
 }
 
-func (r rawConfig) toConfig() agent.Config {
+//go:embed config.json
+var configFS embed.FS
+
+func getConfig() agent.Config {
+	raw := rawConfig{}
+	raw.readDefault()
+	raw.readConfig()
+	raw.readFlags()
+	raw.readEnv()
+	raw.print()
+	return raw.toConfig()
+}
+
+func (r *rawConfig) readDefault() {
+	content, err := configFS.ReadFile("config.json")
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(content, &r)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (r *rawConfig) readConfig() {
+	path := new(string)
+	*path = ""
+
+	v := flag.Lookup("c")
+	if v == nil {
+		v = flag.Lookup("config")
+	}
+	if v != nil {
+		*path = v.Value.String()
+	}
+	cp, ok := os.LookupEnv("CONFIG")
+	if ok {
+		*path = cp
+	}
+	if *path == "" {
+		return
+	}
+
+	content, err := os.ReadFile(*path)
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(content, &r)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (r *rawConfig) readFlags() {
+	flag.StringVar(&r.Addr, "a", r.Addr, "server address")
+	flag.Uint64Var(&r.PollInterval, "p", r.PollInterval, "metrics poll interval in seconds")
+	flag.Uint64Var(&r.ReportInterval, "r", r.ReportInterval, "metrics report interval in seconds")
+	flag.StringVar(&r.Key, "k", r.Key, "hashing key")
+	flag.Uint64Var(&r.RateLimit, "l", r.RateLimit, "report rate limit")
+	flag.StringVar(&r.LogLevel, "log_level", r.LogLevel, "log level")
+	flag.StringVar(&r.PublicKeyPath, "crypto-key", r.PublicKeyPath, "public key PEM path")
+	flag.StringVar(&r.ConfigPath, "config", r.ConfigPath, "config path")
+	flag.StringVar(&r.ConfigPath, "c", r.ConfigPath, "config path (shorthand)")
+	flag.Parse()
+}
+
+func (r *rawConfig) readEnv() {
+	err := env.Parse(r)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (r *rawConfig) print() error {
+	cyaml, err := yaml.Marshal(r)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(cyaml))
+	return nil
+}
+
+func (r *rawConfig) toConfig() agent.Config {
 	return agent.Config{
 		CollectorConfig: collector.Config{
 			PollInterval:   time.Duration(r.PollInterval) * time.Second,
@@ -34,24 +122,4 @@ func (r rawConfig) toConfig() agent.Config {
 		},
 		LogLevel: r.LogLevel,
 	}
-}
-
-func getConfig() agent.Config {
-	raw := rawConfig{}
-
-	flag.StringVar(&raw.Addr, "a", "localhost:8080", "server address")
-	flag.Uint64Var(&raw.PollInterval, "p", 2, "metrics poll interval in seconds")
-	flag.Uint64Var(&raw.ReportInterval, "r", 10, "metrics report interval in seconds")
-	flag.StringVar(&raw.Key, "k", "", "hashing key")
-	flag.Uint64Var(&raw.RateLimit, "l", 2, "report rate limit")
-	flag.StringVar(&raw.LogLevel, "log_level", "info", "log level")
-	flag.StringVar(&raw.PublicKeyPath, "crypto-key", "", "public key PEM path")
-	flag.Parse()
-
-	err := env.Parse(&raw)
-	if err != nil {
-		panic(err)
-	}
-
-	return raw.toConfig()
 }

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -17,6 +17,7 @@ type rawConfig struct {
 	Key            string `env:"KEY"`
 	RateLimit      uint64 `env:"RATE_LIMIT"`
 	LogLevel       string `env:"LOG_LEVEL"`
+	PublicKeyPath  string `env:"CRYPTO_KEY"`
 }
 
 func (r rawConfig) toConfig() agent.Config {
@@ -26,9 +27,10 @@ func (r rawConfig) toConfig() agent.Config {
 			ReportInterval: time.Duration(r.ReportInterval) * time.Second,
 		},
 		ReporterConfig: reporter.Config{
-			Addr:      r.Addr,
-			Key:       r.Key,
-			RateLimit: r.RateLimit,
+			Addr:          r.Addr,
+			Key:           r.Key,
+			RateLimit:     r.RateLimit,
+			PublicKeyPath: r.PublicKeyPath,
 		},
 		LogLevel: r.LogLevel,
 	}
@@ -43,6 +45,7 @@ func getConfig() agent.Config {
 	flag.StringVar(&raw.Key, "k", "", "hashing key")
 	flag.Uint64Var(&raw.RateLimit, "l", 2, "report rate limit")
 	flag.StringVar(&raw.LogLevel, "log_level", "info", "log level")
+	flag.StringVar(&raw.PublicKeyPath, "crypto-key", "", "public key PEM path")
 	flag.Parse()
 
 	err := env.Parse(&raw)

--- a/cmd/agent/config.json
+++ b/cmd/agent/config.json
@@ -1,0 +1,8 @@
+{
+    "address": "localhost:8080",
+    "poll_interval": 2,
+    "report_interval": 10,
+    "rate_limit": 2,
+    "log_level": "info",
+    "crypto_key": ""
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -31,7 +31,6 @@ func main() {
 	go func() { log.Println(http.ListenAndServe("localhost:6060", nil)) }()
 
 	cfg := getConfig()
-	fmt.Printf("agent running...\n%+v\n\n", cfg)
 	err := agent.Run(cfg)
 	if err != nil {
 		panic(err)

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -1,53 +1,125 @@
 package main
 
 import (
+	"embed"
+	"encoding/json"
 	"flag"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/caarlos0/env/v10"
 	"github.com/dlomanov/mon/internal/apps/server"
 	"github.com/dlomanov/mon/internal/apps/server/container"
+	"gopkg.in/yaml.v2"
 )
 
 type rawConfig struct {
-	Addr            string `env:"ADDRESS"`
-	LogLevel        string `env:"LOG_LEVEL"`
-	StoreInterval   uint64 `env:"STORE_INTERVAL"`
-	FileStoragePath string `env:"FILE_STORAGE_PATH"`
-	Restore         bool   `env:"RESTORE"`
-	DatabaseDSN     string `env:"DATABASE_DSN"`
-	Key             string `env:"KEY"`
-	PrivateKeyPath  string `env:"CRYPTO_KEY"`
+	Addr            string `json:"address" env:"ADDRESS"`
+	LogLevel        string `json:"log_level" env:"LOG_LEVEL"`
+	StoreInterval   uint64 `json:"store_interval" env:"STORE_INTERVAL"`
+	FileStoragePath string `json:"file_storage_path" env:"FILE_STORAGE_PATH"`
+	Restore         bool   `json:"restore" env:"RESTORE"`
+	DatabaseDSN     string `json:"database_dsn" env:"DATABASE_DSN"`
+	Key             string `json:"key" env:"KEY"`
+	PrivateKeyPath  string `json:"crypto_key" env:"CRYPTO_KEY"`
+	ConfigPath      string `json:"config" env:"CONFIG"`
 }
+
+//go:embed config.json
+var configFS embed.FS
 
 func getConfig() server.Config {
 	raw := rawConfig{}
+	raw.readDefault()
+	raw.readConfig()
+	raw.readFlags()
+	raw.readEnv()
+	raw.print()
+	return raw.toConfig()
+}
 
-	flag.StringVar(&raw.Addr, "a", "localhost:8080", "server address")
-	flag.StringVar(&raw.LogLevel, "l", "info", "log level")
-	flag.Uint64Var(&raw.StoreInterval, "i", 300, "store interval in seconds")
-	flag.StringVar(&raw.FileStoragePath, "f", "/tmp/metrics-db.json", "file storage path")
-	flag.BoolVar(&raw.Restore, "r", true, "restore metrics from file at server start")
-	flag.StringVar(&raw.DatabaseDSN, "d", "", "database DSN")
-	flag.StringVar(&raw.Key, "k", "", "hashing key")
-	flag.StringVar(&raw.PrivateKeyPath, "crypto-key", `C:\Users\loman\temp\private.pem`, "private key PEM path")
-	flag.Parse()
-
-	err := env.Parse(&raw)
+func (r *rawConfig) readDefault() {
+	content, err := configFS.ReadFile("config.json")
 	if err != nil {
 		panic(err)
 	}
+	err = json.Unmarshal(content, &r)
+	if err != nil {
+		panic(err)
+	}
+}
 
+func (r *rawConfig) readConfig() {
+	path := new(string)
+	*path = ""
+
+	v := flag.Lookup("c")
+	if v == nil {
+		v = flag.Lookup("config")
+	}
+	if v != nil {
+		*path = v.Value.String()
+	}
+	cp, ok := os.LookupEnv("CONFIG")
+	if ok {
+		*path = cp
+	}
+	if *path == "" {
+		return
+	}
+
+	content, err := os.ReadFile(*path)
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(content, &r)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (r *rawConfig) readFlags() {
+	flag.StringVar(&r.Addr, "a", r.Addr, "server address")
+	flag.StringVar(&r.LogLevel, "l", r.LogLevel, "log level")
+	flag.Uint64Var(&r.StoreInterval, "i", r.StoreInterval, "store interval in seconds")
+	flag.StringVar(&r.FileStoragePath, "f", r.FileStoragePath, "file storage path")
+	flag.BoolVar(&r.Restore, "r", r.Restore, "restore metrics from file at server start")
+	flag.StringVar(&r.DatabaseDSN, "d", r.DatabaseDSN, "database DSN")
+	flag.StringVar(&r.Key, "k", r.Key, "hashing key")
+	flag.StringVar(&r.PrivateKeyPath, "crypto-key", r.PrivateKeyPath, "private key PEM path")
+	flag.StringVar(&r.ConfigPath, "config", r.ConfigPath, "config path")
+	flag.StringVar(&r.ConfigPath, "c", r.ConfigPath, "config path (shorthand)")
+	flag.Parse()
+}
+
+func (r *rawConfig) readEnv() {
+	err := env.Parse(r)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (r *rawConfig) print() error {
+	cyaml, err := yaml.Marshal(r)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(cyaml))
+	return nil
+}
+
+func (r *rawConfig) toConfig() server.Config {
 	return server.Config{
 		Config: container.Config{
-			LogLevel:        raw.LogLevel,
-			StoreInterval:   time.Duration(raw.StoreInterval) * time.Second,
-			FileStoragePath: raw.FileStoragePath,
-			Restore:         raw.Restore,
-			DatabaseDSN:     raw.DatabaseDSN,
-			Key:             raw.Key,
-			Addr:            raw.Addr,
-			PrivateKeyPath:  raw.PrivateKeyPath,
+			LogLevel:        r.LogLevel,
+			StoreInterval:   time.Duration(r.StoreInterval) * time.Second,
+			FileStoragePath: r.FileStoragePath,
+			Restore:         r.Restore,
+			DatabaseDSN:     r.DatabaseDSN,
+			Key:             r.Key,
+			Addr:            r.Addr,
+			PrivateKeyPath:  r.PrivateKeyPath,
 		},
 	}
 }

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -17,6 +17,7 @@ type rawConfig struct {
 	Restore         bool   `env:"RESTORE"`
 	DatabaseDSN     string `env:"DATABASE_DSN"`
 	Key             string `env:"KEY"`
+	PrivateKeyPath  string `env:"CRYPTO_KEY"`
 }
 
 func getConfig() server.Config {
@@ -29,6 +30,7 @@ func getConfig() server.Config {
 	flag.BoolVar(&raw.Restore, "r", true, "restore metrics from file at server start")
 	flag.StringVar(&raw.DatabaseDSN, "d", "", "database DSN")
 	flag.StringVar(&raw.Key, "k", "", "hashing key")
+	flag.StringVar(&raw.PrivateKeyPath, "crypto-key", `C:\Users\loman\temp\private.pem`, "private key PEM path")
 	flag.Parse()
 
 	err := env.Parse(&raw)
@@ -45,6 +47,7 @@ func getConfig() server.Config {
 			DatabaseDSN:     raw.DatabaseDSN,
 			Key:             raw.Key,
 			Addr:            raw.Addr,
+			PrivateKeyPath:  raw.PrivateKeyPath,
 		},
 	}
 }

--- a/cmd/server/config.json
+++ b/cmd/server/config.json
@@ -1,0 +1,10 @@
+{
+    "address": "localhost:8080",
+    "log_level": "info",
+    "store_interval": 300,
+    "file_storage_path": "/tmp/metrics-db.json",
+    "restore": true,
+    "database_dsn": "",
+    "key": "",
+    "crypto_key": ""
+}

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
 	google.golang.org/grpc v1.59.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.4.7
 )

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,8 @@ google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/apps/agent/agent.go
+++ b/internal/apps/agent/agent.go
@@ -24,7 +24,11 @@ func Run(cfg Config) (err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	r := reporter.NewReporter(cfg.ReporterConfig, logger, nil)
+	r, err := reporter.NewReporter(cfg.ReporterConfig, logger, nil)
+	if err != nil {
+		logger.Error("failed to create reporter", zap.Error(err))
+		return err
+	}
 	defer r.Close()
 	r.StartWorkers(ctx)
 

--- a/internal/apps/agent/reporter/config.go
+++ b/internal/apps/agent/reporter/config.go
@@ -1,7 +1,8 @@
 package reporter
 
 type Config struct {
-	Addr      string
-	Key       string
-	RateLimit uint64
+	Addr          string
+	Key           string
+	RateLimit     uint64
+	PublicKeyPath string
 }

--- a/internal/apps/agent/reporter/reporter_test.go
+++ b/internal/apps/agent/reporter/reporter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -23,7 +24,8 @@ func TestReporter(t *testing.T) {
 		RateLimit: 1,
 	}
 	client := resty.New()
-	r := reporter.NewReporter(cfg, zaptest.NewLogger(t), client)
+	r, err := reporter.NewReporter(cfg, zaptest.NewLogger(t), client)
+	require.NoError(t, err)
 	defer r.Close()
 
 	httpmock.ActivateNonDefault(client.GetClient())

--- a/internal/apps/server/container/config.go
+++ b/internal/apps/server/container/config.go
@@ -12,4 +12,5 @@ type Config struct {
 	DatabaseDSN     string        // DatabaseDSN is the data source name for connecting to the database.
 	Key             string        // Key is the secret key used for hashing.
 	Addr            string        // Server host and port.
+	PrivateKeyPath  string        // Path to private PEM key for decrypting incoming metrics.
 }

--- a/internal/apps/server/middlewares/decrypter.go
+++ b/internal/apps/server/middlewares/decrypter.go
@@ -1,0 +1,39 @@
+package middlewares
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/dlomanov/mon/internal/services/encrypt"
+	"go.uber.org/zap"
+)
+
+func Decrypter(logger *zap.Logger, dec *encrypt.Decryptor) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, ok := r.Header["Encryption"]
+			if dec == nil || !ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			encBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				logger.Error("failed to read body", zap.Error(err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			r.Body.Close()
+			body, err := dec.Decrypt(encBody)
+			if err != nil {
+				logger.Error("failed to decrypt body", zap.Error(err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/apps/server/server.go
+++ b/internal/apps/server/server.go
@@ -54,6 +54,7 @@ func createRouter(container *container.Container) *chi.Mux {
 	router.Use(middleware.Recoverer)
 	router.Use(middlewares.Logger(logger))
 	router.Use(middlewares.Compressor)
+	router.Use(middlewares.Decrypter(logger, container.Dec))
 	router.Use(middlewares.Hash(container))
 	useSwagger(router, container.Config)
 	router.Post("/update/{type}/{name}/{value}", handlers.UpdateByParams(container))

--- a/internal/services/encrypt/ecrypt_test.go
+++ b/internal/services/encrypt/ecrypt_test.go
@@ -1,0 +1,47 @@
+package encrypt_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/dlomanov/mon/internal/services/encrypt"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncrypt(t *testing.T) {
+	publicKey, privateKey := createKeys(t)
+	enc, err := encrypt.NewEncryptor(publicKey)
+	require.NoError(t, err, "failed to create encryptor")
+	dec, err := encrypt.NewDecryptor(privateKey)
+	require.NoError(t, err, "failed to create decryptor")
+
+	msg := []byte(strings.Repeat("test", 1000))
+	encMsg, err := enc.Encrypt(msg)
+	require.NoError(t, err, "failed to encrypt message")
+	require.NotEqual(t, msg, encMsg)
+	decMsg, err := dec.Decrypt(encMsg)
+	require.NoError(t, err, "failed to decrypt message")
+	require.Equal(t, msg, decMsg)
+}
+
+func createKeys(t *testing.T) (public []byte, private []byte) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+	publicKey := &privateKey.PublicKey
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	})
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	require.NoError(t, err)
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: publicKeyBytes,
+	})
+	return publicKeyPEM, privateKeyPEM
+}

--- a/internal/services/encrypt/encrypt.go
+++ b/internal/services/encrypt/encrypt.go
@@ -1,0 +1,91 @@
+package encrypt
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+)
+
+type (
+	Encryptor struct {
+		publicKey *rsa.PublicKey
+	}
+	Decryptor struct {
+		privateKey *rsa.PrivateKey
+	}
+)
+
+func NewEncryptor(publicKeyPEM []byte) (*Encryptor, error) {
+	publicKeyBlock, _ := pem.Decode(publicKeyPEM)
+	publicKey, err := x509.ParsePKIXPublicKey(publicKeyBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return &Encryptor{
+		publicKey: publicKey.(*rsa.PublicKey),
+	}, nil
+}
+
+func (enc *Encryptor) Encrypt(input []byte) ([]byte, error) {
+	aesKey := make([]byte, 32) // AES 256
+	if _, err := rand.Read(aesKey); err != nil {
+		return nil, err
+	}
+	encAesKey, err := rsa.EncryptPKCS1v15(rand.Reader, enc.publicKey, aesKey)
+	if err != nil {
+		return nil, err
+	}
+	output, err := encryptAES(input, aesKey)
+	if err != nil {
+		return nil, err
+	}
+	return append(encAesKey, output...), nil
+}
+
+func encryptAES(input []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	output := make([]byte, len(input))
+	stream := cipher.NewCTR(block, key[:block.BlockSize()])
+	stream.XORKeyStream(output, input)
+	return output, nil
+}
+
+func NewDecryptor(privateKeyPEM []byte) (*Decryptor, error) {
+	privateKeyBlock, _ := pem.Decode(privateKeyPEM)
+	privateKey, err := x509.ParsePKCS1PrivateKey(privateKeyBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return &Decryptor{
+		privateKey: privateKey,
+	}, nil
+}
+
+func (dec *Decryptor) Decrypt(input []byte) ([]byte, error) {
+	size := dec.privateKey.Size()
+	encAesKey := input[:size]
+	encPayload := input[size:]
+	aesKey, err := rsa.DecryptPKCS1v15(rand.Reader, dec.privateKey, encAesKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return decryptAES(encPayload, aesKey)
+}
+
+func decryptAES(input []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	output := make([]byte, len(input))
+	stream := cipher.NewCTR(block, key[:block.BlockSize()])
+	stream.XORKeyStream(output, input)
+	return output, nil
+}


### PR DESCRIPTION
## Задание по треку «Сервис сбора метрик и алертинга»

Добавьте возможность конфигурации сервера и агента с помощью файла в формате JSON. Нужно поддержать все действующие опции приложения. Имя файла конфигурации должно задаваться через флаг `-c`/`-config` или переменную окружения `CONFIG`. Значения из файла конфигурации должны иметь меньший приоритет, чем флаги или переменные окружения.

Формат файла для сервера:

```
{
    "address": "localhost:8080", // аналог переменной окружения ADDRESS или флага -a
    "restore": true, // аналог переменной окружения RESTORE или флага -r
    "store_interval": "1s", // аналог переменной окружения STORE_INTERVAL или флага -i
    "store_file": "/path/to/file.db", // аналог переменной окружения STORE_FILE или -f
    "database_dsn": "", // аналог переменной окружения DATABASE_DSN или флага -d
    "crypto_key": "/path/to/key.pem" // аналог переменной окружения CRYPTO_KEY или флага -crypto-key
} 
```

Формат файла для агента:

```
{
    "address": "localhost:8080", // аналог переменной окружения ADDRESS или флага -a
    "report_interval": "1s", // аналог переменной окружения REPORT_INTERVAL или флага -r
    "poll_interval": "1s", // аналог переменной окружения POLL_INTERVAL или флага -p
    "crypto_key": "/path/to/key.pem" // аналог переменной окружения CRYPTO_KEY или флага -crypto-key
} 
```